### PR TITLE
Fix Codecov upload condition in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           files: ./coverage.txt


### PR DESCRIPTION
## Summary
- Remove reference to non-existent `matrix.go-version` variable in the Codecov upload condition
- The condition was always false because the workflow only defines `matrix.os`

## Problem
The current condition `if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'` references `matrix.go-version` which doesn't exist in the workflow matrix. This causes the condition to always evaluate to false, preventing Codecov from receiving coverage reports.

## Solution
Simplified the condition to only check for `matrix.os == 'ubuntu-latest'`, ensuring that coverage reports are uploaded from Ubuntu test runs.

🤖 Generated with [Claude Code](https://claude.ai/code)