### PR TITLE
Update Go version requirements to 1.24.4 in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Flags:
 
 ## Requirements
 
-- Go 1.22 or higher
+- Go 1.24.4 or higher
 - Access to Kubernetes cluster (optional - only needed for secret/configmap resolution)
 - Valid kubeconfig file (optional - secrets/configmaps will show placeholders without it)
 

--- a/docs/rdd.md
+++ b/docs/rdd.md
@@ -60,7 +60,7 @@ kenv extract -f deploy.yaml --mode env
 | --------- | ----------- | ---------------------------------------------------------- |
 | **NFR-1** | Performance | 1 000-line manifest + 50 secrets → ≤ 2 s                   |
 | **NFR-2** | Security    | Secret values remain only in memory; never written to disk |
-| **NFR-3** | Runtime     | Go 1.22; supports Linux / macOS / Windows                  |
+| **NFR-3** | Runtime     | Go 1.24.4; supports Linux / macOS / Windows                |
 | **NFR-4** | Portability | Single static binary (CGO disabled)                        |
 | **NFR-5** | Logging     | `--verbose` enables debug; default = warn+                 |
 


### PR DESCRIPTION
## Summary
Update Go version requirements in documentation to match the actual requirement in go.mod (1.24.4)

## Changes
- **README.md**: Update requirement from "Go 1.22 or higher" to "Go 1.24.4 or higher"
- **docs/rdd.md**: Update NFR-3 Runtime from "Go 1.22" to "Go 1.24.4"

## Context
The go.mod file was recently updated to require Go 1.24.4 due to security vulnerabilities in earlier versions (GO-2025-3751, GO-2025-3750, GO-2025-3749, GO-2025-3563). This PR updates the documentation to reflect the actual requirements.

🤖 Generated with [Claude Code](https://claude.ai/code)