### PR TITLE
build: Update Go version from 1.25.5 to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/whywaita/keex
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/whywaita/keex
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Summary
- Update Go directive in go.mod from 1.25.5 to 1.26.0
- All CI workflows use `go-version-file: 'go.mod'` so they will automatically pick up the new version

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] `gofmt -l .` reports no issues
- [x] `go mod tidy` produces no changes