### PR TITLE
fix(ci): use `go run` for govulncheck to fix Go version mismatch

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,5 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
-        run: govulncheck ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## 問題

Security ワークフローの `Vulnerability Check` ジョブが 2026年4月以降、全runで失敗しています。

**根本原因**: `go install golang.org/x/vuln/cmd/govulncheck@latest` が Go 1.24 でビルドされたバイナリを解決することがあり、プロジェクトが要求する Go 1.26+ と互換性がありません。

```
This application uses version go1.24 of the source-processing packages 
but runs version go1.26 of 'go list'
```

## 修正

`go install` + `govulncheck` の2ステップを `go run` 1ステップに統合。

`go run` は常に `setup-go` でインストールされた Go バージョンでビルドされるため、バージョンミスマッチが発生しません。

## 確認

ローカルの Go 1.26.3 環境で `go run` が正常動作することを確認済み。ついでに `golang.org/x/net` の脆弱性 GO-2026-5026 も検出されています。